### PR TITLE
Parses the index from stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 // A CNI IPAM plugin that takes /proc/cmdline and the environment variables and
 // outputs the CNI configuration required for the external IP address for the
-// pod in question.
+// pod in question.  IPAM plugins send and receive JSON on stdout and stdin,
+// respectively, and are passed arguments and configuration information via
+// environment variables and the aforementioned JSON.
 
 import (
 	"encoding/json"
@@ -127,8 +129,8 @@ func ReadProcCmdline() (string, error) {
 	return string(procCmdline), nil
 }
 
-// ReadIndex unmarshals JSON input to read the index argument contained therein.
-func ReadIndex(r io.Reader) (int64, error) {
+// ReadIndexFromJSON unmarshals JSON input to read the index argument contained therein.
+func ReadIndexFromJSON(r io.Reader) (int64, error) {
 	type JSONInput struct {
 		Ipam struct {
 			Index int64 `json:"index"`
@@ -156,7 +158,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Could not populate the IP configuration: ", err)
 	}
-	index, err := ReadIndex(os.Stdin)
+	index, err := ReadIndexFromJSON(os.Stdin)
 	if err != nil {
 		// Fallback to deprecated method.
 		index, err = DiscoverIndex()

--- a/main_test.go
+++ b/main_test.go
@@ -173,12 +173,12 @@ func TestConfigStructure(t *testing.T) {
 	}
 }
 
-func TestReadIndex(t *testing.T) {
+func TestReadIndexFromJSON(t *testing.T) {
 	// Input taken from real input.
 	input := `{"ipam":{"index":4,"type":"index2ip"},"master":"eth0","name":"ipvlan","type":"ipvlan"}`
-	index, err := ReadIndex(strings.NewReader(input))
+	index, err := ReadIndexFromJSON(strings.NewReader(input))
 	if err != nil {
-		t.Error("ReadIndex error:", err)
+		t.Error("ReadIndexFromJSON error:", err)
 	}
 	if index != 4 {
 		t.Error("Index should be 4, but was", index)
@@ -195,7 +195,7 @@ func TestReadIndex(t *testing.T) {
 		`}`,
 	}
 	for _, bad := range badInput {
-		index, err = ReadIndex(strings.NewReader(bad))
+		index, err = ReadIndexFromJSON(strings.NewReader(bad))
 		if err == nil || index >= 0 {
 			t.Errorf("Should have encountered an error on input: '%s'", bad)
 		}


### PR DESCRIPTION
We used to always use `/proc/cmdline`, but now that multus might work soon, we should also support reading in the config from stdin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/index2ip/4)
<!-- Reviewable:end -->
