### PR TITLE
Supporting outputting multiple CNI spec versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/m-lab/index2ip
 
 go 1.16
 
-require github.com/m-lab/go v0.1.45
+require (
+	github.com/containernetworking/cni v1.0.1
+	github.com/m-lab/go v0.1.45
+)

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/containernetworking/cni v1.0.1 h1:9OIL/sZmMYDBe+G8svzILAlulUpaDTUjeAbtH/JNLBo=
+github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -50,6 +52,9 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -101,6 +106,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20191008195207-8e1d251e947d/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -125,6 +131,15 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
+github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
+github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
+github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
+github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -141,6 +156,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -190,6 +206,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -209,6 +226,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
+golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -223,6 +242,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -233,7 +253,10 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -246,10 +269,13 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -291,6 +317,7 @@ golang.org/x/tools v0.0.0-20200409170454-77362c5149f0/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -356,11 +383,16 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containernetworking/cni/pkg/types"
+	cni "github.com/containernetworking/cni/pkg/types/040"
 	"github.com/m-lab/go/rtx"
 )
 
@@ -46,12 +48,19 @@ type DNSConfig struct {
 	Nameservers []string `json:"nameservers"`
 }
 
-// CniConfig holds a complete CNI configuration, including the protocol version.
-type CniConfig struct {
+// CniResult holds a complete CNI result, including the protocol version.
+type CniResult struct {
 	CniVersion string         `json:"cniVersion"`
 	IPs        []*IPConfig    `json:"ips,omitempty"`
 	Routes     []*RouteConfig `json:"routes,omitempty"`
 	DNS        *DNSConfig     `json:"dns,omitempty"`
+}
+
+type JSONInput struct {
+	CNIVersion string `json:"cniVersion"`
+	Ipam       struct {
+		Index int64 `json:"index"`
+	} `json:"ipam"`
 }
 
 // IPaf represents the IP address family.
@@ -62,8 +71,12 @@ const (
 	v6 IPaf = "6"
 )
 
-// ErrNoIPv6 is returned when we attempt to configure IPv6 on a system which has no v6 address.
-var ErrNoIPv6 = errors.New("IPv6 is not supported or configured")
+var (
+	CNIConfig JSONInput
+
+	// ErrNoIPv6 is returned when we attempt to configure IPv6 on a system which has no v6 address.
+	ErrNoIPv6 = errors.New("IPv6 is not supported or configured")
+)
 
 // MakeGenericIPConfig makes IPConfig and DNSConfig objects out of the epoxy command line.
 func MakeGenericIPConfig(procCmdline string, version IPaf) (*IPConfig, *RouteConfig, *DNSConfig, error) {
@@ -106,8 +119,8 @@ func MakeGenericIPConfig(procCmdline string, version IPaf) (*IPConfig, *RouteCon
 }
 
 // MakeIPConfig makes the initial config from /proc/cmdline without incrementing up to the index.
-func MakeIPConfig(procCmdline string) (*CniConfig, error) {
-	config := &CniConfig{CniVersion: cniVersion}
+func MakeIPConfig(procCmdline string) (*CniResult, error) {
+	config := &CniResult{CniVersion: cniVersion}
 
 	ipv4, route4, dnsv4, err := MakeGenericIPConfig(procCmdline, v4)
 	if err != nil {
@@ -224,7 +237,7 @@ func AddIndexToIP(config *IPConfig, index int64) error {
 }
 
 // AddIndexToIPs updates the config in light of the discovered index.
-func AddIndexToIPs(config *CniConfig, index int64) error {
+func AddIndexToIPs(config *CniResult, index int64) error {
 	for _, ip := range config.IPs {
 		if err := AddIndexToIP(ip, index); err != nil {
 			return err
@@ -249,23 +262,11 @@ func MustReadProcCmdline() string {
 	return string(procCmdline)
 }
 
-// ReadIndexFromJSON unmarshals JSON input to read the index argument contained therein.
-func ReadIndexFromJSON(r io.Reader) (int64, error) {
-	type JSONInput struct {
-		Ipam struct {
-			Index int64 `json:"index"`
-		} `json:"ipam"`
-	}
+// ReadJSONInput unmarshals JSON input from stdin into a global variable.
+func ReadJSONInput(r io.Reader) error {
 	dec := json.NewDecoder(r)
-	config := JSONInput{}
-	err := dec.Decode(&config)
-	if err != nil {
-		return -1, err
-	}
-	if config.Ipam.Index == 0 {
-		return -1, errors.New("the index was either 0 or not found")
-	}
-	return config.Ipam.Index, nil
+	err := dec.Decode(&CNIConfig)
+	return err
 }
 
 // Cmd represents the possible CNI operations for an IPAM plugin.
@@ -297,23 +298,24 @@ func ParseCmd(cmd string) Cmd {
 }
 
 // Add responds to the ADD command.
-func Add() {
+func Add() error {
+	err := ReadJSONInput(os.Stdin)
+	rtx.Must(err, "Could not unmarshall JSON from stdin")
 	procCmdline := MustReadProcCmdline()
 	config, err := MakeIPConfig(procCmdline)
 	rtx.Must(err, "Could not populate the IP configuration")
-	index, err := ReadIndexFromJSON(os.Stdin)
-	rtx.Must(err, "Could not discover the index")
-	rtx.Must(AddIndexToIPs(config, index), "Could not manipulate the IP")
-	encoder := json.NewEncoder(os.Stdout)
-	rtx.Must(encoder.Encode(config), "Could not serialize the struct")
+	rtx.Must(AddIndexToIPs(config, CNIConfig.Ipam.Index), "Could not manipulate the IP")
+	data, err := json.Marshal(config)
+	result, err := cni.NewResult(data)
+	return types.PrintResult(result, CNIConfig.CNIVersion)
 }
 
 // Version responds to the VERSION command.
 func Version() {
 	fmt.Fprintf(os.Stdout, `{
-  "cniVersion": %q,
-  "supportedVersions": [ %q ]
-}`, cniVersion, cniVersion)
+  "cniVersion": 0.3.1,
+  "supportedVersions": [ "0.2.0", "0.3.0", "0.3.1", "0.4.0" ]
+}`)
 }
 
 // Put it all together.

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func AddIndexToIP(config *IPConfig, index int64) error {
 		if err != nil {
 			return errors.New("Could not parse IPv4 address: " + config.Address)
 		}
-		if d+index > 255 || index < 0 {
+		if d+index > 255 || index <= 0 {
 			return errors.New("Index out of range for address")
 		}
 		config.Address = fmt.Sprintf("%d.%d.%d.%d/%d", a, b, c, d+index, subnet)
@@ -313,7 +313,7 @@ func Add() error {
 // Version responds to the VERSION command.
 func Version() {
 	fmt.Fprintf(os.Stdout, `{
-  "cniVersion": 0.3.1,
+  "cniVersion": "0.3.1",
   "supportedVersions": [ "0.2.0", "0.3.0", "0.3.1", "0.4.0" ]
 }`)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -103,7 +103,7 @@ func TestAddIndexToIP(t *testing.T) {
 		{"1.2.3.240/26", "::240/64", 5, "1.2.3.245/26", "::245/64"},
 	}
 	for _, testCase := range goodInputPairs {
-		config := &CniConfig{
+		config := &CniResult{
 			IPs: []*IPConfig{
 				{
 					Version: v4,
@@ -141,7 +141,7 @@ func TestAddIndexToIP(t *testing.T) {
 		{"1.2.3.4/26", "1:2::FE/64", 6, "", ""},
 	}
 	for _, testCase := range badInputPairs {
-		config := &CniConfig{
+		config := &CniResult{
 			IPs: []*IPConfig{
 				{
 					Version: v4,
@@ -192,11 +192,19 @@ func TestMustReadProcCmdlineOrEnv(t *testing.T) {
 func TestConfigStructure(t *testing.T) {
 	jsonString := `{
   "cniVersion": "0.2.0",
-  "ip4": {
-      "ip": "1.2.3.4/26",
-      "gateway": "1.2.3.65",
-      "routes": [ { "dst": "0.0.0.0/0" } ]
-  },
+  "ips": [
+	  {
+		 "version": "4",
+         "address": "1.2.3.4/26",
+         "gateway": "1.2.3.65"
+	  }
+  ],
+  "routes": [
+	  {
+		  "dst": "0.0.0.0/0",
+		  "gw": "1.2.3.65"
+	  }
+  ],
   "dns": {
       "nameservers": [
           "8.8.8.8",
@@ -204,22 +212,22 @@ func TestConfigStructure(t *testing.T) {
       ]
   }
 }`
-	config := CniConfig{}
+	config := CniResult{}
 	err := json.Unmarshal([]byte(jsonString), &config)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func TestReadIndexFromJSON(t *testing.T) {
+func TestReadJSONInput(t *testing.T) {
 	// Input taken from real input.
 	input := `{"ipam":{"index":4,"type":"index2ip"},"master":"eth0","name":"ipvlan","type":"ipvlan"}`
-	index, err := ReadIndexFromJSON(strings.NewReader(input))
+	err := ReadJSONInput(strings.NewReader(input))
 	if err != nil {
-		t.Error("ReadIndexFromJSON error:", err)
+		t.Error("ReadJSONInput error:", err)
 	}
-	if index != 4 {
-		t.Error("Index should be 4, but was", index)
+	if CNIConfig.Ipam.Index != 4 {
+		t.Error("Index should be 4, but was", CNIConfig.Ipam.Index)
 	}
 
 	// Now try with bad input
@@ -232,10 +240,11 @@ func TestReadIndexFromJSON(t *testing.T) {
 		`{{}`,
 		`}`,
 	}
+	CNIConfig.Ipam.Index = 0
 	for _, bad := range badInput {
-		index, err = ReadIndexFromJSON(strings.NewReader(bad))
-		if err == nil || index >= 0 {
-			t.Errorf("Should have encountered an error on input: '%s'", bad)
+		ReadJSONInput(strings.NewReader(bad))
+		if CNIConfig.Ipam.Index != 0 {
+			t.Errorf("Discovering index should have failed, but got index: %v", CNIConfig.Ipam.Index)
 		}
 	}
 }
@@ -258,8 +267,8 @@ func AddEndToEnd(t *testing.T, addcmd string) {
 	defer revertCni()
 
 	// The IP address in this test should come from the parsed index on stdin.
-	output := WithInputTestEndToEnd(t, addcmd, `{"ipam":{"index":5,"type":"index2ip"},"master":"eth0","name":"ipvlan","type":"ipvlan"}`)
-	config := CniConfig{}
+	output := WithInputTestEndToEnd(t, addcmd, `{"cniVersion": "0.3.1", "ipam":{"index":5,"type":"index2ip"},"master":"eth0","name":"ipvlan","type":"ipvlan"}`)
+	config := CniResult{}
 	rtx.Must(json.Unmarshal(output, &config), "Could not unmarshal")
 	if config.CniVersion != "0.3.1" || config.IPs[0].Gateway != "4.14.159.65" {
 		t.Error("Bad data output from index2ip: ", string(output))

--- a/main_test.go
+++ b/main_test.go
@@ -273,7 +273,7 @@ func AddEndToEnd(t *testing.T, addcmd string) {
 	if config.CniVersion != "0.3.1" || config.IPs[0].Gateway != "4.14.159.65" {
 		t.Error("Bad data output from index2ip: ", string(output))
 	}
-	if "4.14.159.117/26" != config.IPs[0].Address {
+	if config.IPs[0].Address != "4.14.159.117/26" {
 		t.Error("Wrong IP returned when index 5 was provided")
 	}
 }


### PR DESCRIPTION
Currently, this plugin can _only_ output CNI spec. 0.3.1. This presents a problem for migrating away from version 0.2.0, which is what is [configured in the various Network Attachment Definitions in the k8s-support repository](https://github.com/m-lab/k8s-support/blob/master/k8s/networks/networks.jsonnet#L58). If we deploy the plugin to nodes, then network initialization will fail, since the cluster will be expecting 0.2.0 output. If we try to update the cluster first, then things will also fail, since the cluster will be expecting 0.3.1, while the currently deployed index2ip only supports 0.2.0.

This PR causes index2ip to return the result format requested in the JSON input on stdin. This should allow us to deploy this updated plugin without needing to modify the cluster. Then once the plugin is fully deployed to all nodes, _then_ we can worry about updating the version specified in the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/index2ip/20)
<!-- Reviewable:end -->
